### PR TITLE
Missed Capital Letter

### DIFF
--- a/prebuilt/common/lib/content-types.properties
+++ b/prebuilt/common/lib/content-types.properties
@@ -2,7 +2,7 @@
 
 docm=application/vnd.ms-word.document.macroenabled.12
 xlsb=application/vnd.ms-excel.sheet.binary.macroenabled.12
-xlsm=application/vnd.ms-excel.sheet.macroEnabled.12
+xlsm=application/vnd.ms-excel.sheet.macroenabled.12
 ppsm=application/vnd.ms-powerpoint.slideshow.macroenabled.12
 ppsx=application/vnd.openxmlformats-officedocument.presentationml.slideshow
 pptm=application/vnd.ms-powerpoint.presentation.macroenabled.12


### PR DESCRIPTION
I missed a capital letter for an excel mimetype. All are now
converted to lowercase.

Change-Id: I1b0958fbc7b6b01df0f6e7b3da9a1d920bfb2fad